### PR TITLE
Removed id key; id is now default for channel key

### DIFF
--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -422,26 +422,26 @@ class RealTimeClient extends ApiClient
                     break;
 
                 case 'channel_created':
-                    $this->getChannelById($payload['channel']['id'])->then(function (Channel $channel) {
+                    $this->getChannelById($payload['channel'])->then(function (Channel $channel) {
                         $this->channels[$channel->getId()] = $channel;
                     });
                     break;
 
                 case 'channel_deleted':
-                    unset($this->channels[$payload['channel']['id']]);
+                    unset($this->channels[$payload['channel']]);
                     break;
 
                 case 'channel_rename':
-                    $this->channels[$payload['channel']['id']]->data['name']
+                    $this->channels[$payload['channel']]->data['name']
                         = $payload['channel']['name'];
                     break;
 
                 case 'channel_archive':
-                    $this->channels[$payload['channel']['id']]->data['is_archived'] = true;
+                    $this->channels[$payload['channel']]->data['is_archived'] = true;
                     break;
 
                 case 'channel_unarchive':
-                    $this->channels[$payload['channel']['id']]->data['is_archived'] = false;
+                    $this->channels[$payload['channel']]->data['is_archived'] = false;
                     break;
 
                 case 'group_joined':


### PR DESCRIPTION
Slack no longer sends the channel id in the `id` key, the id is now the value sent for `channel`.

## Fixes
$ https://github.com/Expensify/Expensify/issues/89118

## Tests
1. Created a test channel in Slack (#deetertest)
1. Dropped a log line on [line 440 of RealTimeClient.php](https://github.com/Expensify/slack-client/blob/6e985c6ffde43d1465c25b1fa12ba0c988656eb9/src/RealTimeClient.php#L440) that dumped the value of `$payload`.
1. Started the `slackPresenceListener` service locally.
1. Archived my Slack channel.
1. Verified my log line line showed and observed the output of `$payload` 
```
2018-11-08T01:12:01.053540+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [hmmm] [deetergp] Slack\RealTimeClient - Here's the payload ~~ payload: {"type":"channel_archive","channel":"CDVT63PA5","user":"U4UDDL537","is_moved":0,"event_ts":"1541639521.721200"}'
```
6. Verified that the PHP error occurred shortly thereafter:
```
2018-11-08T01:12:01.072166+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [dbug] INSERT INTO serverErrors( created, uuid, message, email, accountID, requestID, source ) VALUES( '2018-11-08 01:12:01', 'WARN_1c741a88a004c38c30fee447b0505cd0', 'PHP Warning: Illegal string offset \'id\' - 23e855c2a90dbfd907184d7f2c993c69', null, null, 'L5PGjp', 'api' );
2018-11-08T01:12:01.077564+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] Stack Trace:
2018-11-08T01:12:01.077873+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 0. () :
2018-11-08T01:12:01.078112+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 1. Slack\RealTimeClient->onMessage() /vagrant/Web-Expensify/vendor/coderstephen/slack-client/src/RealTimeClient.php:125
2018-11-08T01:12:01.078351+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 2. Slack\RealTimeClient->Slack\{closure}() :
2018-11-08T01:12:01.078578+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 3. call_user_func_array() /vagrant/Web-Expensify/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:64
2018-11-08T01:12:01.078807+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 4. Evenement\EventEmitter->emit() :
2018-11-08T01:12:01.079019+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 5. ReflectionMethod->invokeArgs() /vagrant/Web-Expensify/vendor/devristo/phpws/src/Devristo/Phpws/Reflection/FullAccessWrapper.php:25
2018-11-08T01:12:01.079312+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 6. Devristo\Phpws\Reflection\FullAccessWrapper->__call() /vagrant/Web-Expensify/vendor/devristo/phpws/src/Devristo/Phpws/Client/WebSocket.php:141
2018-11-08T01:12:01.079787+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 7. Devristo\Phpws\Client\WebSocket->Devristo\Phpws\Client\{closure}() :
2018-11-08T01:12:01.080045+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 8. call_user_func_array() /vagrant/Web-Expensify/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:64
2018-11-08T01:12:01.080277+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 9. Evenement\EventEmitter->emit() /vagrant/Web-Expensify/vendor/devristo/phpws/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php:149
2018-11-08T01:12:01.080549+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 10. Devristo\Phpws\Protocol\WebSocketTransportHybi->processMessageFrame() /vagrant/Web-Expensify/vendor/devristo/phpws/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php:109
2018-11-08T01:12:01.080822+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 11. Devristo\Phpws\Protocol\WebSocketTransportHybi->handleData() /vagrant/Web-Expensify/vendor/devristo/phpws/src/Devristo/Phpws/Protocol/WebSocketTransport.php:61
2018-11-08T01:12:01.081238+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 12. Devristo\Phpws\Protocol\WebSocketTransport->Devristo\Phpws\Protocol\{closure}() :
2018-11-08T01:12:01.081667+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 13. call_user_func_array() /vagrant/Web-Expensify/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php:64
2018-11-08T01:12:01.081945+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 14. Evenement\EventEmitter->emit() /vagrant/Web-Expensify/vendor/react/stream/src/Stream.php:173
2018-11-08T01:12:01.082190+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 15. React\Stream\Stream->handleData() :
2018-11-08T01:12:01.082433+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 16. call_user_func() /vagrant/Web-Expensify/vendor/react/event-loop/src/StreamSelectLoop.php:236
2018-11-08T01:12:01.082661+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 17. React\EventLoop\StreamSelectLoop->waitForStreamActivity() /vagrant/Web-Expensify/vendor/react/event-loop/src/StreamSelectLoop.php:205
2018-11-08T01:12:01.082877+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 18. React\EventLoop\StreamSelectLoop->run() /vagrant/Web-Expensify/lib/Slack/PresenceListener.php:79
2018-11-08T01:12:01.083094+00:00 expensidev php: L5PGjp /git/expensify.com/script/slackPresenceListener.php we@dont.know !script! ?api? [info] 19. Expensify\Slack\PresenceListener->run() /vagrant/Web-Expensify/script/slackPresenceListener.php:21
```
7. Made the changes in this PR and re ran steps 1-5
1. Restarted `slackPresenceListener`.
1. Un-archived and re-archived the channel.
1. Verified the log line showed but the error did not.

## QA
1. 🚫 