### PR TITLE
Fix Illegal offset type in isset

### DIFF
--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -422,17 +422,17 @@ class RealTimeClient extends ApiClient
                     break;
 
                 case 'channel_created':
-                    $this->getChannelById($payload['channel'])->then(function (Channel $channel) {
+                    $this->getChannelById($payload['channel']['id'])->then(function (Channel $channel) {
                         $this->channels[$channel->getId()] = $channel;
                     });
                     break;
 
                 case 'channel_deleted':
-                    unset($this->channels[$payload['channel']]);
+                    unset($this->channels[$payload['channel']['id']]);
                     break;
 
                 case 'channel_rename':
-                    $this->channels[$payload['channel']]->data['name']
+                    $this->channels[$payload['channel']['id']]->data['name']
                         = $payload['channel']['name'];
                     break;
 


### PR DESCRIPTION
In a [previous PR](https://github.com/Expensify/slack-client/pull/2/), I mistakenly got rid of the `id` key for `channel_created`, `channel_deleted`, and `channel_rename` based on the assumption that because they got rid of it for `channel_archive` and `channel_unarchive` they must have gotten rid fo it for all. That was an incorrect assumption. This PR restores that key.

cc @tgolen 

## Related
Relates to https://github.com/Expensify/Expensify/issues/93282